### PR TITLE
Allow to pass options to delete form

### DIFF
--- a/FormFactory/DeleteCommentFormFactory.php
+++ b/FormFactory/DeleteCommentFormFactory.php
@@ -50,9 +50,9 @@ class DeleteCommentFormFactory implements DeleteCommentFormFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function createForm()
+    public function createForm($data = null, $options = array())
     {
-        $builder = $this->formFactory->createNamedBuilder($this->name, $this->type, null, array('method' => 'PATCH'));
+        $builder = $this->formFactory->createNamedBuilder($this->name, $this->type, $data, $options);
 
         return $builder->getForm();
     }


### PR DESCRIPTION
This allows users to pass options to the delete comment form so that it can be deleted via ajax.